### PR TITLE
Support 402 Payment Required Error Codes

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -17,6 +17,10 @@ export class HttpError extends Error {
     return new HttpError(message || "Unauthorized", 401, errorData);
   }
 
+  public static PaymentRequired(message?: string, errorData?: any) {
+    return new HttpError(message || "Payment Required", 402, errorData);
+  }
+
   public static Forbidden(message?: string, errorData?: any) {
     return new HttpError(message || "Forbidden", 403, errorData);
   }


### PR DESCRIPTION
Hey, I'm using this for a bitcoin payments proxy and use the 402 error code, just upstreaming in case you're cool with supporting.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/402